### PR TITLE
Add the ability to specify the CDN (and host local themes)

### DIFF
--- a/jquery.themeswitcher.js
+++ b/jquery.themeswitcher.js
@@ -18,6 +18,7 @@
 			width: 175,
 			rounded: true,
 			imgpath: "",
+			themepath: "https://ajax.googleapis.com/ajax/libs/jqueryui/",
 			jqueryuiversion: "1.8.10",
 			initialtext: "Switch Theme",
 			buttonpretext: "Theme:",
@@ -341,9 +342,9 @@
 		var url = data.url;
 
 		if (!url) {
-			var urlPrefix = "https://ajax.googleapis.com/ajax/libs/jqueryui/"+settings.jqueryuiversion+"/themes/";
-			url = urlPrefix+data.name+"/jquery-ui.css";
-			currentStyle = $('link[href^="'+urlPrefix+'"]').first();
+		    var urlPrefix = settings.themepath + settings.jqueryuiversion + "/themes/";
+		    url = urlPrefix + data.name + "/jquery-ui.css";
+		    currentStyle = $('link[href^="' + urlPrefix + '"]').first();
 		}
 
 		if (currentStyle.length) {


### PR DESCRIPTION
Added a property to specify the theme path. All the dev will need to do
is replicate the CDN storage style locally for theme support to work.
(i.e. /css/1.9.0/themes/ui-lightness/jquery-ui.css). This does mean that
the downloaded themes from jquery will need to be tweaked slightly (file
name).
