### PR TITLE
Add themecss option to control the name of the jQuery UI css file

### DIFF
--- a/jquery.themeswitcher.js
+++ b/jquery.themeswitcher.js
@@ -19,6 +19,7 @@
 			rounded: true,
 			imgpath: "",
 			themepath: "https://ajax.googleapis.com/ajax/libs/jqueryui/",
+			themecss: "jquery-ui.css",
 			jqueryuiversion: "1.8.10",
 			initialtext: "Switch Theme",
 			buttonpretext: "Theme:",
@@ -343,7 +344,7 @@
 
 		if (!url) {
 		    var urlPrefix = settings.themepath + settings.jqueryuiversion + "/themes/";
-		    url = urlPrefix + data.name + "/jquery-ui.css";
+		    url = urlPrefix + data.name + "/" + settings.themecss;
 		    currentStyle = $('link[href^="' + urlPrefix + '"]').first();
 		}
 


### PR DESCRIPTION
It is useful to choose from jquery-ui.css, jquery-ui.min.css and jquery.ui.theme.css, which are available for every core jQuery UI theme.
