### PR TITLE
Add storage option (cookie, local, session) to choose where to store the last used theme

### DIFF
--- a/jquery.themeswitcher.js
+++ b/jquery.themeswitcher.js
@@ -24,6 +24,7 @@
 			buttonpretext: "Theme:",
 			closeonselect: true,
 			buttonheight: 14,
+			storage: "cookie", // local, session
 			cookiename: "jquery-ui-theme",
 			themes: [],
 			additionalthemes: [],
@@ -229,9 +230,11 @@
     		})
     		.appendTo(switcherLink);
     		
-    	// load the default theme or the theme stored in the cookie
-    	if( $.cookie(settings.cookiename) ){
-    		updateTheme( findTheme($.cookie(settings.cookiename)) );
+    	// load the default theme or the theme stored in the local
+    	// storage, in the session storage or in the cookie
+    	var lastTheme = getStoredTheme();
+    	if( lastTheme ){
+    		updateTheme( findTheme(lastTheme) );
     		
     	}else if( settings.loadtheme.length ){
     		updateTheme( findTheme(settings.loadtheme) );
@@ -331,6 +334,35 @@
     			.appendTo(listLink);
     	});
     	
+        function getStoredTheme() {
+          var storage;
+          if (settings.storage === "local")
+            storage = localStorage;
+          else if (settings.storage === "session")
+            storage = sessionStorage;
+          if (storage) {
+            var value = storage.getItem(settings.cookiename);
+            value = value && JSON.parse(value);
+            return value && value.name;
+          } else if (settings.storage === "cookie")
+            return $.cookie(settings.cookiename);
+        }
+
+        function setStoredTheme(name) {
+          var storage;
+          if (settings.storage === "local")
+            storage = localStorage;
+          else if (settings.storage === "session")
+            storage = sessionStorage;
+          if (storage)
+            storage.setItem(settings.cookiename,
+              JSON.stringify({ name: name }));
+          else if (settings.storage === "cookie")
+            $.cookie(settings.cookiename, name,
+                { expires: settings.cookieexpires, path: settings.cookiepath }
+            );
+        }
+
     	function updateTheme(data){
     		if( settings.onselect !== null )
     			settings.onselect();
@@ -358,9 +390,7 @@
 			style.appendTo("head");
 		}
     		
-    		$.cookie(settings.cookiename, data.name, 
-                { expires: settings.cookieexpires, path: settings.cookiepath }
-            );
+    		setStoredTheme(data.name);
             
     		switcherDiv.find(".jquery-ui-switcher-title").text(settings.buttonpretext + " " + data.title);
     		


### PR DESCRIPTION
The last used theme needs not be stored as a cookie.  While it could be inspected on the server side, usually it is useful on the client side only.  In the usual scenario, it can be stored in localStorage or sessionStorage in the browser, which are available in all browsers for some time (IE8 and newer, e.g.).  Also, it avoids increasing the cookie space and questions about security and cookies sent over the network.
